### PR TITLE
Added ssl_timeout parameter

### DIFF
--- a/dracclient/client.py
+++ b/dracclient/client.py
@@ -46,10 +46,11 @@ class DRACClient(object):
             protocol='https',
             ssl_retries=constants.DEFAULT_WSMAN_SSL_ERROR_RETRIES,
             ssl_retry_delay=constants.DEFAULT_WSMAN_SSL_ERROR_RETRY_DELAY_SEC,
-            ssl_timeout=constants.SSL_TIMEOUT
             ready_retries=constants.DEFAULT_IDRAC_IS_READY_RETRIES,
             ready_retry_delay=(
-                constants.DEFAULT_IDRAC_IS_READY_RETRY_DELAY_SEC)):
+                constants.DEFAULT_IDRAC_IS_READY_RETRY_DELAY_SEC),
+            ssl_timeout=constants.SSL_TIMEOUT
+            ):
         """Creates client object
 
         :param host: hostname or IP of the DRAC interface
@@ -61,15 +62,15 @@ class DRACClient(object):
         :param ssl_retries: number of resends to attempt on SSL failures
         :param ssl_retry_delay: number of seconds to wait between
                                 retries on SSL failures
-        :param ssl_timeout: number of seconds before aborting SSL request
         :param ready_retries: number of times to check if the iDRAC is
                               ready
         :param ready_retry_delay: number of seconds to wait between
                                   checks if the iDRAC is ready
+        :param ssl_timeout: number of seconds before aborting SSL request
         """
         self.client = WSManClient(host, username, password, port, path,
                                   protocol, ssl_retries, ssl_retry_delay,
-                                  ssl_timeout, ready_retries, ready_retry_delay)
+                                  ready_retries, ready_retry_delay, ssl_timeout)
         self._job_mgmt = job.JobManagement(self.client)
         self._power_mgmt = bios.PowerManagement(self.client)
         self._boot_mgmt = bios.BootManagement(self.client)

--- a/dracclient/client.py
+++ b/dracclient/client.py
@@ -46,6 +46,7 @@ class DRACClient(object):
             protocol='https',
             ssl_retries=constants.DEFAULT_WSMAN_SSL_ERROR_RETRIES,
             ssl_retry_delay=constants.DEFAULT_WSMAN_SSL_ERROR_RETRY_DELAY_SEC,
+            ssl_timeout=constants.SSL_TIMEOUT
             ready_retries=constants.DEFAULT_IDRAC_IS_READY_RETRIES,
             ready_retry_delay=(
                 constants.DEFAULT_IDRAC_IS_READY_RETRY_DELAY_SEC)):
@@ -60,6 +61,7 @@ class DRACClient(object):
         :param ssl_retries: number of resends to attempt on SSL failures
         :param ssl_retry_delay: number of seconds to wait between
                                 retries on SSL failures
+        :param ssl_timeout: number of seconds before aborting SSL request
         :param ready_retries: number of times to check if the iDRAC is
                               ready
         :param ready_retry_delay: number of seconds to wait between
@@ -67,7 +69,7 @@ class DRACClient(object):
         """
         self.client = WSManClient(host, username, password, port, path,
                                   protocol, ssl_retries, ssl_retry_delay,
-                                  ready_retries, ready_retry_delay)
+                                  ssl_timeout, ready_retries, ready_retry_delay)
         self._job_mgmt = job.JobManagement(self.client)
         self._power_mgmt = bios.PowerManagement(self.client)
         self._boot_mgmt = bios.BootManagement(self.client)

--- a/dracclient/client.py
+++ b/dracclient/client.py
@@ -582,7 +582,8 @@ class WSManClient(wsman.Client):
             ssl_retry_delay=constants.DEFAULT_WSMAN_SSL_ERROR_RETRY_DELAY_SEC,
             ready_retries=constants.DEFAULT_IDRAC_IS_READY_RETRIES,
             ready_retry_delay=(
-                constants.DEFAULT_IDRAC_IS_READY_RETRY_DELAY_SEC)):
+                constants.DEFAULT_IDRAC_IS_READY_RETRY_DELAY_SEC),
+            ssl_timeout=constants.SSL_TIMEOUT):
         """Creates client object
 
         :param host: hostname or IP of the DRAC interface
@@ -598,6 +599,7 @@ class WSManClient(wsman.Client):
                               ready
         :param ready_retry_delay: number of seconds to wait between
                                   checks if the iDRAC is ready
+        :param ssl_timeout: number of seconds before aborting SSL request
         """
         super(WSManClient, self).__init__(host, username, password,
                                           port, path, protocol, ssl_retries,

--- a/dracclient/constants.py
+++ b/dracclient/constants.py
@@ -34,3 +34,6 @@ PRIMARY_STATUS = {
 
 # binary unit constants
 UNITS_KI = 2 ** 10
+
+# Requests timeout
+SSL_TIMEOUT = 2

--- a/dracclient/wsman.py
+++ b/dracclient/wsman.py
@@ -45,7 +45,8 @@ class Client(object):
                  protocol='https',
                  ssl_retries=constants.DEFAULT_WSMAN_SSL_ERROR_RETRIES,
                  ssl_retry_delay=(
-                     constants.DEFAULT_WSMAN_SSL_ERROR_RETRY_DELAY_SEC)):
+                     constants.DEFAULT_WSMAN_SSL_ERROR_RETRY_DELAY_SEC),
+                 ssl_timeout=constants.SSL_TIMEOUT):
         """Creates client object
 
         :param host: hostname or IP of the DRAC interface
@@ -57,6 +58,7 @@ class Client(object):
         :param ssl_retries: number of resends to attempt on SSL failures
         :param ssl_retry_delay: number of seconds to wait between
                                 retries on SSL failures
+        :param ssl_timeout: number of seconds before aborting SSL query
         """
 
         self.host = host
@@ -67,6 +69,7 @@ class Client(object):
         self.protocol = protocol
         self.ssl_retries = ssl_retries
         self.ssl_retry_delay = ssl_retry_delay
+        self.ssl_timeout = ssl_timeout
         self.endpoint = ('%(protocol)s://%(host)s:%(port)s%(path)s' % {
             'protocol': self.protocol,
             'host': self.host,
@@ -87,6 +90,7 @@ class Client(object):
                                                      self.password),
                     data=payload,
                     # TODO(ifarkas): enable cert verification
+                    timeout=self.ssl_timeout,
                     verify=False)
                 break
             except (requests.exceptions.ConnectionError,


### PR DESCRIPTION
When a host will simply not reply or the firewall will block you, with current version the timeout takes forever. When doing batches, this can be a huge problem.

Added a `SSL_TIMEOUT` constant, and constructor parameters, to provide a `timeout=` param to `requests.post` calls.